### PR TITLE
Context-aware minimum term length

### DIFF
--- a/spec/searchable_by_spec.rb
+++ b/spec/searchable_by_spec.rb
@@ -67,9 +67,16 @@ describe SearchableBy do
     expect(Post.search_by('recip').pluck(:title)).to match_array(%w[ax1 ax2 bx1 bx2 ab1])
   end
 
-  it 'supports min term length' do
+  it 'supports min term length in context' do
+    # single term acts as expected
     expect(User.search_by('+ir')).to be_empty
     expect(User.search_by('irs')).to match_array([USERS[:a]])
+
+    # excludes min length term when there's at least one viable term
+    expect(User.search_by('my recipe')).to match_array([USERS[:a], USERS[:a]])
+
+    # includes min length term when in a phrase
+    expect(User.search_by('"my recipe"')).to match_array([USERS[:a]])
   end
 
   it 'searches within scopes' do


### PR DESCRIPTION
Searching for e.g. `"my recipe"` when the minimum term length is `3`, causes a `(FALSE OR FALSE)` clause to be added to the query and thus no records are returned. 

This should really only be applied when there are no other viable terms. For the example above we would query for just `"recipe"` and skip the `(FALSE OR FALSE)` clause.