### PR TITLE
Explicit Wildcards

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    searchable-by (0.6.0)
+    searchable-by (0.6.1)
       activerecord
 
 GEM

--- a/lib/searchable_by/column.rb
+++ b/lib/searchable_by/column.rb
@@ -51,17 +51,22 @@ module SearchableBy
       when :exact
         term.downcase!
         scope.and(node.lower.eq(term))
+      when :full
+        escape_term!(term)
+        scope.and(node.matches(term))
       when :prefix
-        term.gsub!('%', '\%')
-        term.gsub!('_', '\_')
+        escape_term!(term)
         scope.and(node.matches("#{term}%"))
-      else # :all (wraps term in wildcards) or :wildcard (explicit wildcards)
-        term.gsub!('%', '\%')
-        term.gsub!('_', '\_')
-        term.gsub!(wildcard, '%') if wildcard
-        pattern = type == :wildcard ? term : "%#{term}%"
-        scope.and(node.matches(pattern))
+      else # :all (wraps term in wildcards)
+        escape_term!(term)
+        scope.and(node.matches("%#{term}%"))
       end
+    end
+
+    def escape_term!(term)
+      term.gsub!('%', '\%')
+      term.gsub!('_', '\_')
+      term.gsub!(wildcard, '%') if wildcard
     end
   end
 end

--- a/lib/searchable_by/column.rb
+++ b/lib/searchable_by/column.rb
@@ -55,11 +55,12 @@ module SearchableBy
         term.gsub!('%', '\%')
         term.gsub!('_', '\_')
         scope.and(node.matches("#{term}%"))
-      else
+      else # :all (wraps term in wildcards) or :wildcard (explicit wildcards)
         term.gsub!('%', '\%')
         term.gsub!('_', '\_')
         term.gsub!(wildcard, '%') if wildcard
-        scope.and(node.matches("%#{term}%"))
+        pattern = type == :wildcard ? term : "%#{term}%"
+        scope.and(node.matches(pattern))
       end
     end
   end

--- a/searchable-by.gemspec
+++ b/searchable-by.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'searchable-by'
-  s.version     = '0.6.0'
+  s.version     = '0.6.1'
   s.authors     = ['Dimitrij Denissenko']
   s.email       = ['dimitrij@blacksquaremedia.com']
   s.summary     = 'Generate search scopes'

--- a/spec/searchable_by_spec.rb
+++ b/spec/searchable_by_spec.rb
@@ -8,7 +8,7 @@ describe SearchableBy do
 
   it 'configures correctly' do
     expect(AbstractModel._searchable_by_config.columns.size).to eq(1)
-    expect(Post._searchable_by_config.columns.size).to eq(5)
+    expect(Post._searchable_by_config.columns.size).to eq(6)
   end
 
   it 'generates SQL' do
@@ -64,6 +64,9 @@ describe SearchableBy do
     # title uses match_phrase: :exact
     expect(Post.search_by('"ab"').pluck(:title)).to be_empty
     expect(Post.search_by('"ab1"').pluck(:title)).to match_array(%w[ab1])
+
+    # country uses match: :full in combination with wildcard: '*'
+    expect(Post.search_by('*kingdom').pluck(:title)).to match_array(%w[ax1 ax2 ab1])
 
     # body uses match: :all (default)
     expect(Post.search_by('recip').pluck(:title)).to match_array(%w[ax1 ax2 bx1 bx2 ab1])

--- a/spec/searchable_by_spec.rb
+++ b/spec/searchable_by_spec.rb
@@ -24,10 +24,12 @@ describe SearchableBy do
     expect(sql).to include(%("posts"."body" LIKE '%foo\\%bar%'))
 
     sql = User.search_by('uni*dom').to_sql
-    expect(sql).to include(%("users"."country" LIKE '%uni%dom%'))
+    expect(sql).to include(%("users"."country" LIKE 'uni%dom'))
+    expect(sql).to include(%("users"."bio" LIKE '%uni*dom%'))
 
     sql = User.search_by('"uni * dom"').to_sql
-    expect(sql).to include(%("users"."country" LIKE '%uni % dom%'))
+    expect(sql).to include(%("users"."country" LIKE 'uni % dom'))
+    expect(sql).to include(%("users"."bio" LIKE '%uni * dom%'))
   end
 
   it 'searches' do
@@ -89,8 +91,8 @@ describe SearchableBy do
   end
 
   it 'supports wildcard searching' do
-    expect(User.search_by('uni*dom')).to match_array(USERS.values_at(:a))
-    expect(User.search_by('uni*o')).to match_array(USERS.values_at(:a, :b))
-    expect(User.search_by('uni*of*dom')).to be_empty
+    expect(User.search_by('*uni*dom')).to match_array(USERS.values_at(:a))
+    expect(User.search_by('*uni*o*')).to match_array(USERS.values_at(:a, :b))
+    expect(User.search_by('*uni*of*dom')).to be_empty
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ class User < AbstractModel
 
   searchable_by min_length: 3 do
     column :bio
-    column :country, wildcard: '*'
+    column :country, wildcard: '*', match: :wildcard
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ class User < AbstractModel
 
   searchable_by min_length: 3 do
     column :bio
-    column :country, wildcard: '*', match: :wildcard
+    column :country, wildcard: '*', match: :full
   end
 end
 
@@ -44,6 +44,7 @@ class Post < AbstractModel
     column :title, match: :prefix, match_phrase: :exact
     column :body
     column proc { User.arel_table[:name] }, match: :exact
+    column proc { User.arel_table[:country] }, wildcard: '*', match: :full
     column { User.arel_table.alias('reviewers_posts')[:name] }
 
     scope do


### PR DESCRIPTION
Adding the `:full` value for options `match` and `match_phrase`. 
While the default `:all` wraps a term or phrase in wildcards and `:prefix` allows for wildcards anywhere after the pattern prefix, `:full` matches the full term ensuring only the wildcards specified in the search pattern are used.