### PR TITLE
Allow wildcard on exact match

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    searchable-by (0.6.1)
+    searchable-by (0.7.0)
       activerecord
 
 GEM

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ class Post < ActiveRecord::Base
     column { Author.arel_table[:name] }
     column { Arel::Nodes::NamedFunction.new('CONCAT', [arel_table[:prefix], arel_table[:suffix]]) }
 
+    # Allow custom wildcard replacement using a match e.g. searching for `"My*Post"` will query `ILIKE 'My%Post'`.
+    column :metadata, match: :prefix, match_phrase: :exact, wildcard: '*'
+
     # Support custom scopes.
     scope do
       joins(:author)

--- a/lib/searchable_by/util.rb
+++ b/lib/searchable_by/util.rb
@@ -29,12 +29,6 @@ module SearchableBy
 
     def self.build_clauses(columns, values)
       values.map do |value|
-        # TODO: remove when removing min_length option from columns
-        usable = columns.all? do |column|
-          column.send(:usable?, value)
-        end
-        next unless usable
-
         group = columns.map do |column|
           column.build_condition(value)
         end.tap(&:compact!)

--- a/searchable-by.gemspec
+++ b/searchable-by.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'searchable-by'
-  s.version     = '0.6.1'
+  s.version     = '0.7.0'
   s.authors     = ['Dimitrij Denissenko']
   s.email       = ['dimitrij@blacksquaremedia.com']
   s.summary     = 'Generate search scopes'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ class User < AbstractModel
 
   searchable_by min_length: 3 do
     column :bio
-    column :country, wildcard: '*', match: :full
+    column :country, wildcard: '*', match: :exact
   end
 end
 
@@ -44,7 +44,7 @@ class Post < AbstractModel
     column :title, match: :prefix, match_phrase: :exact
     column :body
     column proc { User.arel_table[:name] }, match: :exact
-    column proc { User.arel_table[:country] }, wildcard: '*', match: :full
+    column proc { User.arel_table[:country] }, wildcard: '*', match: :exact
     column { User.arel_table.alias('reviewers_posts')[:name] }
 
     scope do


### PR DESCRIPTION
Removing the `:full` option in favour of combining `match: :exact` with `wildcard` option.